### PR TITLE
Add Jest test suite for key components

### DIFF
--- a/__tests__/Home.test.js
+++ b/__tests__/Home.test.js
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Home from '@/app/page';
+
+jest.mock('@/components/TrainingCard', () => ({
+  __esModule: true,
+  default: ({ program }) => <div data-testid="card">{program.trainingArea}</div>,
+}));
+
+const mockGetDocs = jest.fn();
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  getDocs: (...args) => mockGetDocs(...args),
+}));
+
+describe('Home page', () => {
+  beforeEach(() => {
+    mockGetDocs.mockResolvedValue({
+      docs: Array.from({ length: 10 }, (_, i) => ({
+        id: String(i + 1),
+        data: () => ({
+          trainingArea: `Area ${i + 1}`,
+          trainerName: `Trainer ${i + 1}`,
+          schedule: new Date().toISOString(),
+          venue: `Venue ${i + 1}`,
+        }),
+      })),
+    });
+  });
+
+  it('paginates programs', async () => {
+    render(<Home />);
+    expect(await screen.findAllByTestId('card')).toHaveLength(9);
+    fireEvent.click(screen.getByRole('button', { name: '2' }));
+    await waitFor(() => expect(screen.getAllByTestId('card')).toHaveLength(1));
+  });
+
+  it('filters programs based on search query', async () => {
+    render(<Home />);
+    const input = await screen.findByPlaceholderText('Search by training area...');
+    fireEvent.change(input, { target: { value: 'Area 10' } });
+    await waitFor(() => expect(screen.getAllByTestId('card')).toHaveLength(1));
+    expect(screen.getByText('Area 10')).toBeInTheDocument();
+  });
+});

--- a/__tests__/LoginPage.test.js
+++ b/__tests__/LoginPage.test.js
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import LoginPage from '@/app/login/page';
+
+jest.mock('@/firebase/config', () => ({ auth: {} }));
+
+const mockSignIn = jest.fn();
+jest.mock('firebase/auth', () => ({
+  signInWithEmailAndPassword: (...args) => mockSignIn(...args),
+}));
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    mockSignIn.mockReset();
+  });
+
+  it('shows success message on successful login', async () => {
+    mockSignIn.mockResolvedValue({});
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'a@b.com' } });
+    fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'pass' } });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    expect(await screen.findByText(/✅ Logged In/i)).toBeInTheDocument();
+  });
+
+  it('shows error message on failed login', async () => {
+    mockSignIn.mockRejectedValue(new Error('fail'));
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'a@b.com' } });
+    fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'pass' } });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    expect(await screen.findByText(/Invalid email or password/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/SearchBar.test.js
+++ b/__tests__/SearchBar.test.js
@@ -1,0 +1,12 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SearchBar from '@/components/SearchBar';
+
+describe('SearchBar', () => {
+  it('calls setSearchQuery on input change', () => {
+    const setSearchQuery = jest.fn();
+    render(<SearchBar searchQuery="" setSearchQuery={setSearchQuery} />);
+    const input = screen.getByPlaceholderText('Search by training area...');
+    fireEvent.change(input, { target: { value: 'cardio' } });
+    expect(setSearchQuery).toHaveBeenCalledWith('cardio');
+  });
+});

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,10 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testEnvironment: 'jest-environment-jsdom',
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+
+// Mock Next.js Link component for tests
+jest.mock('next/link', () => {
+  return ({ children, ...props }) => React.createElement('a', props, children);
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "firebase": "^12.0.0",
@@ -17,6 +18,11 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "eslint": "^9",
-    "eslint-config-next": "15.4.5"
+    "eslint-config-next": "15.4.5",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.5.1",
+    "@testing-library/user-event": "^14.4.3",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- configure Jest and testing library for the project
- add tests for SearchBar, Login page and Home page behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aafb21c5048328a4663491360bab5d